### PR TITLE
Hide internal emails

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -219,8 +219,9 @@ h1 .controls {
   float: right;
 }
 
-li no-show{
-
+.no-bullet{
+  list-style-type: none;
+  padding-left: 0px;
 }
 
 /* Buttons */

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -49,7 +49,7 @@ table.table td.vertical-centered {
   background-image: url('empty.gif')
 }
 
-.attachment-glyphicon{
+.attachment{
   position:relative;
   z-index:2;
 }

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -31,18 +31,36 @@ table.table td.vertical-centered {
 
 /*  Page specific */
 
-.timeline {
-  margin-bottom:  0.7em;
-  padding-bottom: 0.7em;
+.timeline-header, .timeline {
+  padding-bottom: 0.3em;
+  padding-top: 0.3em;
   border-bottom: 1px solid #000000;
+  position:relative;
+}
+
+.timeline .modal-link span{
+  position:absolute;
+  width:100%;
+  height:100%;
+  top:0;
+  left:0;
+  text-decoration:none;
+  z-index:1;
+  background-image: url('empty.gif')
+}
+
+.attachment-glyphicon{
+  position:relative;
+  z-index:2;
+}
+
+.timeline:hover{
+background-color: #e1e1e8;
+cursor: pointer;
 }
 
 .table-header {
   font-weight: bold;
-}
-
-.attachment {
-  padding-bottom: 1em;
 }
 
 .email-border {

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -219,6 +219,10 @@ h1 .controls {
   float: right;
 }
 
+li no-show{
+
+}
+
 /* Buttons */
 
 a, a:visited {

--- a/app/models/email_message.rb
+++ b/app/models/email_message.rb
@@ -118,4 +118,18 @@ class EmailMessage < ActiveRecord::Base
     end
     sections
   end
+
+  # See if an email is internal communication (there is prob a better way of doing this)
+  def internal
+    sender = self.participants_with_delivery('from').map {|d| d.domain}
+    recipients = self.participants_with_delivery('to').map {|d| d.domain} + self.participants_with_delivery('cc').map {|d| d.domain}
+    all = sender + recipients
+    # I can't do this => requester = parse_email(Authorisation.self.requester.email)[:domain]
+    # 2 criterias: recipients domain (cc + to) must match the sender (to), and all must match the requester domain
+      if recipients.uniq.length == 1 && recipients.uniq == sender # && all.uniq == requester
+        true
+      else
+        false
+    end
+  end
 end

--- a/app/models/message_attachment.rb
+++ b/app/models/message_attachment.rb
@@ -13,4 +13,10 @@ class MessageAttachment < ActiveRecord::Base
   		true
   	end
   end
+
+  def type
+    extension = File.extname(self.filename)
+    extension[0] = ''
+    extension.upcase
+  end
 end

--- a/app/views/authorisations/_authorisation.html.erb
+++ b/app/views/authorisations/_authorisation.html.erb
@@ -13,7 +13,7 @@
 	<td class="vertical-centered"><%= authorisation.status.capitalize %></td>
 	<td class="vertical-centered">
 		<% if authorisation.synced & authorisation.enabled %>
-			<%= link_to 'view', authorisation_path(authorisation), class: 'btn btn-block btn-default' %>
+			<%= link_to 'View', authorisation_path(authorisation), class: 'btn btn-block btn-default' %>
 		<% else %>
 			<a href="" class="btn btn-block btn-default" role="button" disabled="disabled">View</a>
 		<% end %>

--- a/app/views/authorisations/_email.html.erb
+++ b/app/views/authorisations/_email.html.erb
@@ -1,16 +1,22 @@
 <div class="modal-header">
-  <p>
-    <b><%= (email.participants_with_delivery('from').map {|p| p.fullname + " <" + p.email + ">"}).join(', ') %></b>
-  </p>
-  <p>
-    to <%= (email.participants_with_delivery('to').map {|p| p.fullname + " <" + p.email + ">"}).join(', ') %>,
-    <% if !(email.participants_with_delivery('cc').map {|p| p.fullname}).empty? %>
-      <%= (email.participants_with_delivery('cc').map {|p| p.fullname + " <" + p.email + ">"}).join(', ') %>
-    <% end %>
-    <% if !(email.participants_with_delivery('bcc').map {|p| p.fullname}).empty? %>
-      Bcc: <%= (email.participants_with_delivery('bcc').map {|p| p.fullname + " <" + p.email + ">"}).join(', bcc: ') %>
-    <% end %>
-  </p>
+  <div class="row">
+    <div class="col-md-9">
+      <p>
+        <b><%= (email.participants_with_delivery('from').map {|p| p.fullname + " <" + p.email + ">"}).join(', ') %></b>
+        <br>
+        to <%= (email.participants_with_delivery('to').map {|p| p.fullname + " <" + p.email + ">"}).join(', ') %>,
+        <% if !(email.participants_with_delivery('cc').map {|p| p.fullname}).empty? %>
+          <%= (email.participants_with_delivery('cc').map {|p| p.fullname + " <" + p.email + ">"}).join(', ') %>
+        <% end %>
+        <% if !(email.participants_with_delivery('bcc').map {|p| p.fullname}).empty? %>
+          Bcc: <%= (email.participants_with_delivery('bcc').map {|p| p.fullname + " <" + p.email + ">"}).join(', bcc: ') %>
+        <% end %>
+      </p>
+    </div>
+    <div class="col-md-3">
+      <p class="text-right"><%= email.created_at.strftime("%d %b %y") %></p>
+    </div>
+  </div>
 </div>
 <div class="modal-body">
   <% if email.body_html.empty? %>

--- a/app/views/authorisations/_email.html.erb
+++ b/app/views/authorisations/_email.html.erb
@@ -1,3 +1,9 @@
+<% if email.internal %>
+<div class="modal-header">
+      <p> Internal communication to <%= email.participants_with_delivery('from').map {|d| d.domain}%> </p>
+</div>
+<% else %>
+
 <div class="modal-header">
   <div class="row">
     <div class="col-md-9">
@@ -41,7 +47,7 @@
   	<% end %>
   <% end %>
 </div>
-<% if !Rails.env.production? %>
-  <p><small>(Testing: <%= email.id %>)</small></p>
 <% end %>
+
+
 <hr class="email-border" />

--- a/app/views/authorisations/_thread.html.erb
+++ b/app/views/authorisations/_thread.html.erb
@@ -21,12 +21,12 @@
   </div>
 </div>
 
-  <div class="col-md-1">
+  <div class="col-md-2">
     <p>
       <% if thread.first_email_date.strftime("%d/%m/%y") == thread.last_email_date.strftime("%d/%m/%y") %>
-      <%= thread.first_email_date.strftime("%d/%m/%y") %>
+      <%= thread.first_email_date.strftime("%d %b %y") %>
       <% else %>
-      <%= thread.last_email_date.strftime("%d/%m/%y") %> - <%= thread.first_email_date.strftime("%d/%m/%y") %>
+      <%= thread.last_email_date.strftime("%d %b %y") %> -<br> <%= thread.first_email_date.strftime("%d %b %y") %>
       <% end %>
     </p>
   </div>
@@ -42,7 +42,7 @@
         <% end %>
     </ul>
   </div>
-  <div class="col-md-3">
+  <div class="col-md-2">
     <p>
       <%= thread.subject %>
     </p>

--- a/app/views/authorisations/_thread.html.erb
+++ b/app/views/authorisations/_thread.html.erb
@@ -52,8 +52,8 @@
       <% if !attachment.inline %>
         <div class="row"> <!-- List attachment as rows-->
           <div class="col-md-3">
-            <a href="<%= attachment_path(attachment) %>" target="_blank" class="btn btn-primary attachment" aria-label="Left Align">
-              <span class="attachment-glyphicon glyphicon <%= mimetype_visual(attachment.mime_type) %>" aria-hidden="true"></span>
+            <a href="<%= attachment_path(attachment) %>" target="_blank" class="btn btn-primary attachment attachment-glyphicon" aria-label="Left Align">
+              <span class="glyphicon <%= mimetype_visual(attachment.mime_type) %>" aria-hidden="true"></span>
             </a>
           </div>
           <div class="col-md-9">

--- a/app/views/authorisations/_thread.html.erb
+++ b/app/views/authorisations/_thread.html.erb
@@ -26,7 +26,9 @@
       <% if thread.first_email_date.strftime("%d/%m/%y") == thread.last_email_date.strftime("%d/%m/%y") %>
       <%= thread.first_email_date.strftime("%d %b %y") %>
       <% else %>
-      <%= thread.last_email_date.strftime("%d %b %y") %> -<br> <%= thread.first_email_date.strftime("%d %b %y") %>
+      <%= thread.last_email_date.strftime("%d %b %y") %> -<br>
+      <%= thread.first_email_date.strftime("%d %b %y") %> <br>
+      (<%= (thread.last_email_date - thread.first_email_date).to_i %> days)
       <% end %>
     </p>
   </div>

--- a/app/views/authorisations/_thread.html.erb
+++ b/app/views/authorisations/_thread.html.erb
@@ -23,10 +23,10 @@
 
   <div class="col-md-1">
     <p>
-      <% if thread.first_email_date == thread.last_email_date %>
+      <% if thread.first_email_date.strftime("%d/%m/%y") == thread.last_email_date.strftime("%d/%m/%y") %>
       <%= thread.first_email_date.strftime("%d/%m/%y") %>
       <% else %>
-      <%= thread.first_email_date.strftime("%d/%m/%y") %> - <%= thread.last_email_date.strftime("%d/%m/%y") %>
+      <%= thread.last_email_date.strftime("%d/%m/%y") %> - <%= thread.first_email_date.strftime("%d/%m/%y") %>
       <% end %>
     </p>
   </div>

--- a/app/views/authorisations/_thread.html.erb
+++ b/app/views/authorisations/_thread.html.erb
@@ -31,7 +31,7 @@
     </p>
   </div>
   <div class="col-md-3">
-    <ul>
+    <ul class="no-bullet">
         <% thread.participants.each do |participant| %>
           <li>
             <%= participant.fullname %>

--- a/app/views/authorisations/_thread.html.erb
+++ b/app/views/authorisations/_thread.html.erb
@@ -1,4 +1,26 @@
 <div class="row timeline">
+
+<!-- Modal launcher -->
+<a class="modal-link" data-toggle="modal" data-target="#thread-<%= thread.id %>">
+  <span></span>
+</a>
+
+<!-- Modal -->
+<div class="modal fade" id="thread-<%= thread.id %>" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-header top_header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h2><%= thread.subject %></h2>
+      </div>
+      <%= render partial: 'authorisations/email', collection: thread.email_messages.order('internal_date desc')%>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
   <div class="col-md-1">
     <p>
       <% if thread.first_email_date == thread.last_email_date %>
@@ -7,27 +29,6 @@
       <%= thread.first_email_date.strftime("%d/%m/%y") %> - <%= thread.last_email_date.strftime("%d/%m/%y") %>
       <% end %>
     </p>
-  </div>
-  <div class="col-md-1">
-    <button type="button" class="btn btn-primary" aria-label="Left Align"
-    data-toggle="modal" data-target="#thread-<%= thread.id %>">
-      <span class="glyphicon glyphicon-envelope" aria-hidden="true"></span>
-    </button>
-    <!-- Modal -->
-    <div class="modal fade" id="thread-<%= thread.id %>" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-      <div class="modal-dialog modal-lg" role="document">
-        <div class="modal-content">
-          <div class="modal-header top_header">
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <h2><%= thread.subject %></h2>
-          </div>
-          <%= render partial: 'authorisations/email', collection: thread.email_messages.order('internal_date desc')%>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
-          </div>
-        </div>
-      </div>
-    </div>
   </div>
   <div class="col-md-3">
     <ul>
@@ -49,10 +50,10 @@
   <div class="col-md-4"> <!-- Merge last two columns-->
     <% thread.message_attachments.each do |attachment| %>
       <% if !attachment.inline %>
-        <div class="row attachment"> <!-- List attachment as rows-->
+        <div class="row"> <!-- List attachment as rows-->
           <div class="col-md-3">
-            <a href="<%= attachment_path(attachment) %>" target="_blank" class="btn btn-primary" aria-label="Left Align">
-              <span class="glyphicon <%= mimetype_visual(attachment.mime_type) %>" aria-hidden="true"></span>
+            <a href="<%= attachment_path(attachment) %>" target="_blank" class="btn btn-primary attachment" aria-label="Left Align">
+              <span class="attachment-glyphicon glyphicon <%= mimetype_visual(attachment.mime_type) %>" aria-hidden="true"></span>
             </a>
           </div>
           <div class="col-md-9">

--- a/app/views/authorisations/_thread.html.erb
+++ b/app/views/authorisations/_thread.html.erb
@@ -44,7 +44,7 @@
         <% end %>
     </ul>
   </div>
-  <div class="col-md-2">
+  <div class="col-md-3">
     <p>
       <%= thread.subject %>
       <% if thread.email_messages.count > 1 %>
@@ -53,20 +53,20 @@
     </p>
   </div>
   <div class="col-md-4"> <!-- Merge last two columns-->
-    <% thread.message_attachments.each do |attachment| %>
+    <ul class="no-bullet">
+      <% thread.message_attachments.each do |attachment| %>
       <% if !attachment.inline %>
-        <div class="row"> <!-- List attachment as rows-->
-          <div class="col-md-3">
-            <a href="<%= attachment_path(attachment) %>" target="_blank" class="btn btn-primary attachment attachment-glyphicon" aria-label="Left Align">
-              <span class="glyphicon <%= mimetype_visual(attachment.mime_type) %>" aria-hidden="true"></span>
-            </a>
-          </div>
-          <div class="col-md-9">
-            <%= attachment.filename %>
-          </div>
-        </div>
+      <li>
+        <% if !attachment.filename.empty?  %>
+        <a href="<%= attachment_path(attachment) %>" target="_blank" class="attachment" aria-label="Left Align">
+          (<%= attachment.type %>)
+          <%= attachment.filename %>
+        </a>
+        <% end %>
+      </li>
       <% end %>
-    <% end %>
+      <% end %>
+    </ul>
   </div>
 </div>
 

--- a/app/views/authorisations/_thread.html.erb
+++ b/app/views/authorisations/_thread.html.erb
@@ -28,7 +28,7 @@
       <% else %>
       <%= thread.last_email_date.strftime("%d %b %y") %> -<br>
       <%= thread.first_email_date.strftime("%d %b %y") %> <br>
-      (<%= (thread.last_email_date - thread.first_email_date).to_i %> days)
+      (<%= (thread.last_email_date.jd - thread.first_email_date.jd).to_i %> days)
       <% end %>
     </p>
   </div>
@@ -47,6 +47,9 @@
   <div class="col-md-2">
     <p>
       <%= thread.subject %>
+      <% if thread.email_messages.count > 1 %>
+        (<%= thread.email_messages.count %>)
+      <% end %>
     </p>
   </div>
   <div class="col-md-4"> <!-- Merge last two columns-->

--- a/app/views/authorisations/show.html.erb
+++ b/app/views/authorisations/show.html.erb
@@ -5,9 +5,8 @@
   <div class="row timeline-header table-header">
       <div class="col-md-2">Date</div>
       <div class="col-md-3">People</div>
-      <div class="col-md-2">Subject</div>
-      <div class="col-md-1">Type</div>
-      <div class="col-md-3">Attachment</div>
+      <div class="col-md-3">Subject</div>
+      <div class="col-md-4">Attachment</div>
   </div>
   <div>
   <% if @threads.any? %>

--- a/app/views/authorisations/show.html.erb
+++ b/app/views/authorisations/show.html.erb
@@ -1,17 +1,18 @@
-<h1 class="text-center"><%= @authorisation.scope %></h1>
 <div class="container">
-  <div class="row timeline table-header">
+  <div class="row centered">
+    <h1><%= @authorisation.scope %></h1>
+  </div>
+  <div class="row timeline-header table-header">
       <div class="col-md-1">Date</div>
-      <div class="col-md-1">Type</div>
       <div class="col-md-3">People</div>
       <div class="col-md-3">Subject</div>
       <div class="col-md-1">Type</div>
       <div class="col-md-3">Attachment</div>
   </div>
-</div>
-<div>
-<% if @threads.any? %>
-	<%= render partial: 'authorisations/thread', collection: @threads %>
-	<%= will_paginate @threads %>
-<% end %>
+  <div>
+  <% if @threads.any? %>
+  	<%= render partial: 'authorisations/thread', collection: @threads %>
+  	<%= will_paginate @threads %>
+  <% end %>
+  </div>
 </div>

--- a/app/views/authorisations/show.html.erb
+++ b/app/views/authorisations/show.html.erb
@@ -3,9 +3,9 @@
     <h1><%= @authorisation.scope %></h1>
   </div>
   <div class="row timeline-header table-header">
-      <div class="col-md-1">Date</div>
+      <div class="col-md-2">Date</div>
       <div class="col-md-3">People</div>
-      <div class="col-md-3">Subject</div>
+      <div class="col-md-2">Subject</div>
       <div class="col-md-1">Type</div>
       <div class="col-md-3">Attachment</div>
   </div>

--- a/npm-debug.log
+++ b/npm-debug.log
@@ -1,0 +1,18 @@
+0 info it worked if it ends with ok
+1 verbose cli [ 'node', '/usr/local/bin/npm', 'start' ]
+2 info using npm@2.1.17
+3 info using node@v0.10.29
+4 verbose node symlink /usr/local/bin/node
+5 verbose stack Error: ENOENT, open '/Users/amaurydeclosset/GC_Code/passiton/package.json'
+6 verbose cwd /Users/amaurydeclosset/GC_Code/passiton
+7 error Darwin 14.1.0
+8 error argv "node" "/usr/local/bin/npm" "start"
+9 error node v0.10.29
+10 error npm  v2.1.17
+11 error path /Users/amaurydeclosset/GC_Code/passiton/package.json
+12 error code ENOENT
+13 error errno 34
+14 error enoent ENOENT, open '/Users/amaurydeclosset/GC_Code/passiton/package.json'
+14 error enoent This is most likely not a problem with npm itself
+14 error enoent and is related to npm not being able to find a file.
+15 verbose exit [ 34, true ]


### PR DESCRIPTION
@octaveauger - this one was ambitious for my skills. I want to add the concept of "internal emails", i.e. emails that are sent within an organisation (a concept in [Turing](http://techcrunch.com/2015/10/01/turing-email-wants-to-make-sending-emails-as-fun-as-using-slack/)). If it is internal, emails would be hidden.

It kinda work but I wanted to add one more condition: the authorisation requester (e.g. amaury@gocardless.com) must match the internal domain of all on the email chain (e.g. octave@gocardless.com, x@gocardless.com...). The thing that blocked me is how to call the "self" instance of the class Authorisation (which is in a different model file). Just couldn't figure out how to do it. 

**Do not merge** Help appreciated :-)

Not in scope yet: Get a checkbox for granter to say "yes I want to share internal emails" or not.

Not an urgent one, just playing a bit, might be a nice one to have to address privacy concerns.
