### PR TITLE
Sync gmail labels per User and Thread

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -357,6 +357,11 @@ table {
   color: #E0E0E0;
 }
 
+.glyphicon.warning {
+  color : #f0ad4e;
+  font-size : 16px ;
+}
+
 /* mixins, variables, etc. */
 
 $grayMediumLight: #eaeaea;

--- a/app/models/email_thread.rb
+++ b/app/models/email_thread.rb
@@ -25,11 +25,11 @@ class EmailThread < ActiveRecord::Base
 		Time.at((self.email_messages.order('email_messages.internal_date desc').first.internal_date.to_i/1000).to_i).utc.to_datetime
 	end
 
-	# Returns an array of label names for the thread
+	# Returns an array of label names, types etc. for the thread
 	def readable_labels
 		user_labels = {}
 		self.authorisation.granter.labels.all.each do |user_label|
-			user_labels[user_label.label_id] = user_label.name
+			user_labels[user_label.label_id] = { id: user_label.id, label_id: user_label.label_id, name: user_label.name, label_type: user_label.label_type }
 		end
 		readable_labels = []
 		JSON.parse(self.labels).each do |label_id|

--- a/app/models/gmail.rb
+++ b/app/models/gmail.rb
@@ -56,6 +56,11 @@ class Gmail
 		execute(opts)
 	end
 
+	def list_labels
+		opts = DEFAULT_OPTIONS.merge(:api_method => @service.users.labels.list)
+		execute(opts)
+	end
+
 	private
 
 		def execute(opts)

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,0 +1,26 @@
+class Label < ActiveRecord::Base
+  belongs_to :user
+
+  def self.sync_gmail(user)
+  	client = Gmail.new(user.tokens.last.fresh_token)
+	labels = client.list_labels
+	current_labels = user.labels.all
+	labels['labels'].each do |label|
+		if (label['type'] != 'system' or ['STARRED', 'IMPORTANT'].include? label['id']) and !current_labels.where(label_id: label['id']).any?
+			user.labels.create(
+				label_id: label['id'],
+				name: label['name'],
+				label_type: label['type']
+			)
+		end
+	end
+  end
+
+  def self.to_array(user)
+  	list = []
+  	user.labels.all.each do |label|
+  		list.push(label.label_id)
+  	end
+  	list
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ActiveRecord::Base
   has_many :email_threads, through: :requested_authorisations
   has_many :email_messages, through: :email_threads
   has_many :message_attachments, through: :email_messages
+  has_many :labels
 
   # Manages the connection to Gmail and the User population
   def self.find_for_google_oauth2(access_token, signed_in_resource=nil)

--- a/app/views/authorisations/_thread.html.erb
+++ b/app/views/authorisations/_thread.html.erb
@@ -39,6 +39,17 @@
   </div>
   <div class="col-md-3">
     <p>
+      <% thread.readable_labels.each do |labels| %>
+        <% if labels[:label_type] == 'system' %>
+          <% if labels[:name] == 'IMPORTANT' %>
+            <span class="glyphicon glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+            <% else %>
+            <span class="label label-default"><%= labels[:name] %></span>
+          <% end %>
+        <% elsif (labels[:label_type] == 'user' && labels[:name] != 'Boomerang' && labels[:name] != 'Boomerang-Returned') %>
+          <span class="label label-warning"><%= labels[:name] %></span>
+        <% end %>
+      <% end %>
       <b><%= thread.subject %></b>
       <% if thread.email_messages.count > 1 %>
         (<%= thread.email_messages.count %>)

--- a/app/views/authorisations/_thread.html.erb
+++ b/app/views/authorisations/_thread.html.erb
@@ -42,12 +42,14 @@
       <% thread.readable_labels.each do |labels| %>
         <% if labels[:label_type] == 'system' %>
           <% if labels[:name] == 'IMPORTANT' %>
-            <span class="glyphicon glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+            <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+            <% elsif labels[:name] == 'STARRED' %>
+            <span class="glyphicon glyphicon-star warning" aria-hidden="true"></span>
             <% else %>
             <span class="label label-default"><%= labels[:name] %></span>
           <% end %>
         <% elsif (labels[:label_type] == 'user' && labels[:name] != 'Boomerang' && labels[:name] != 'Boomerang-Returned') %>
-          <span class="label label-warning"><%= labels[:name] %></span>
+          <span class="label label-primary"><%= labels[:name] %></span>
         <% end %>
       <% end %>
       <b><%= thread.subject %></b>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -233,7 +233,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], scope: 'email,profile,gmail.readonly', access_type: 'offline'
+  config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], scope: 'email,profile,gmail.readonly,gmail.labels', access_type: 'offline'
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_passiton_session'
+Rails.application.config.session_store :cookie_store, key: '_passiton_session', expire_after: 30.minutes

--- a/db/migrate/20151025193900_add_labels_to_threads.rb
+++ b/db/migrate/20151025193900_add_labels_to_threads.rb
@@ -1,0 +1,5 @@
+class AddLabelsToThreads < ActiveRecord::Migration
+  def change
+  	add_column :email_threads, :labels, :text
+  end
+end

--- a/db/migrate/20151025195740_create_labels.rb
+++ b/db/migrate/20151025195740_create_labels.rb
@@ -1,0 +1,14 @@
+class CreateLabels < ActiveRecord::Migration
+  def change
+    create_table :labels do |t|
+      t.references :user, index: true
+      t.string :label_id
+      t.string :name
+      t.string :label_type
+
+      t.timestamps
+    end
+    add_index :labels, :label_id
+    add_index :labels, :label_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151018133716) do
+ActiveRecord::Schema.define(version: 20151025195740) do
 
   create_table "attachment_headers", force: true do |t|
     t.integer  "message_attachment_id"
@@ -77,10 +77,24 @@ ActiveRecord::Schema.define(version: 20151018133716) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "synced"
+    t.text     "labels"
   end
 
   add_index "email_threads", ["synced"], name: "index_email_threads_on_synced"
   add_index "email_threads", ["thread_id"], name: "index_email_threads_on_thread_id"
+
+  create_table "labels", force: true do |t|
+    t.integer  "user_id"
+    t.string   "label_id"
+    t.string   "name"
+    t.string   "label_type"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "labels", ["label_id"], name: "index_labels_on_label_id"
+  add_index "labels", ["label_type"], name: "index_labels_on_label_type"
+  add_index "labels", ["user_id"], name: "index_labels_on_user_id"
 
   create_table "message_attachments", force: true do |t|
     t.integer  "email_message_id"

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -8,6 +8,8 @@ namespace :testing do
   	MessageAttachment.destroy_all
   	MessageParticipant.destroy_all
   	Participant.destroy_all
+    Tag.destroy_all
+    Label.destroy_all
   end
 
   desc "Update tags for all threads"

--- a/spec/models/labels_spec.rb
+++ b/spec/models/labels_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Labels do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
@adeclosset labels are now 1) synced from gmail and 2) accessible in a human readable way.

I haven't included them in the view yet: basically by calling @mythread.readable_labels you get an array with the label names (e.g ['IMPORTANT', 'Boomerang']). I let you add it before we merge.
