### PR TITLE
Using token instead of id for authorisation paths

### DIFF
--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -69,7 +69,6 @@ function initialize() {
 
 	// Toggle the display of an element when a trigger is clicked (without hiding the trigger)
 	$('[data-role="trigger-toggle-display"]').off('click').on('click', function(e) {
-		console.log('expand');
 		e.preventDefault();
 		$($(this).attr('data-target')).toggleClass('hide');
 	});

--- a/app/controllers/authorisations_controller.rb
+++ b/app/controllers/authorisations_controller.rb
@@ -11,9 +11,9 @@ class AuthorisationsController < ApplicationController
   end
 
   def show
-  	@authorisation = current_user.granted_authorisations.find_by(id: params[:id])
+  	@authorisation = current_user.granted_authorisations.find_by(token: params[:id])
     if @authorisation.nil?
-      @authorisation = current_user.requested_authorisations.find_by(id: params[:id])
+      @authorisation = current_user.requested_authorisations.find_by(token: params[:id])
       @viewer_type = 'requester' # if user is both granter and requester, they'll be seen as requester in the view
     else
       @viewer_type = 'granter'
@@ -99,7 +99,7 @@ class AuthorisationsController < ApplicationController
   end
 
   def update
-    @authorisation = current_user.granted_authorisations.find(params[:id])
+    @authorisation = current_user.granted_authorisations.find_by(token: params[:id])
     if @authorisation.nil?
       flash[:alert] = 'Something went wrong, try again'
       render 'granting'

--- a/app/models/authorisation.rb
+++ b/app/models/authorisation.rb
@@ -2,6 +2,8 @@ include ApplicationHelper
 include ThreadHelper
 
 class Authorisation < ActiveRecord::Base
+	include Tokenable
+	
 	belongs_to :requester, class_name: 'User'
 	belongs_to :granter, class_name: 'User'
 	validates :requester_id, presence: true

--- a/app/models/concerns/tokenable.rb
+++ b/app/models/concerns/tokenable.rb
@@ -1,0 +1,16 @@
+module Tokenable
+  extend ActiveSupport::Concern
+
+  included do
+    before_create :generate_token
+  end
+
+  protected
+
+  def generate_token
+    self.token = loop do
+      random_token = SecureRandom.urlsafe_base64(nil, false)
+      break random_token unless self.class.exists?(token: random_token)
+    end
+  end
+end

--- a/app/views/authorisation_mailer/authorisation_granted.html.erb
+++ b/app/views/authorisation_mailer/authorisation_granted.html.erb
@@ -4,6 +4,6 @@
 </p>
 <p>
 	To see the emails shared with you, please follow this link:
-	<div class="btn btn-primary centered"><%= link_to 'See context', authorisation_url(@authorisation) %></div>
+	<div class="btn btn-primary centered"><%= link_to 'See context', authorisation_url(@authorisation.token) %></div>
 </p>
 <%= render partial: 'authorisation_mailer/email_footer' %>

--- a/app/views/authorisation_mailer/authorisation_granted.text.erb
+++ b/app/views/authorisation_mailer/authorisation_granted.text.erb
@@ -4,6 +4,6 @@ Context given
 <%= @authorisation.granter.full_identity %> has given you context on "<%= @authorisation.scope %>".
 
 To see the emails shared with you, please follow this link:
-<%= authorisation_url(@authorisation) %>
+<%= authorisation_url(@authorisation.token) %>
 
 <%= render partial: 'authorisation_mailer/email_footer' %>

--- a/app/views/authorisations/_authorisation.html.erb
+++ b/app/views/authorisations/_authorisation.html.erb
@@ -31,7 +31,7 @@
 	</div>
 	<div class="col-sm-3 col-xs-12">
 		<% if authorisation.synced & authorisation.enabled %>
-			<%= link_to 'View', authorisation_path(authorisation), class: 'btn btn-default btn-granting pull-right' %>
+			<%= link_to 'View', authorisation_path(authorisation.token), class: 'btn btn-default btn-granting pull-right' %>
 		<% elsif authorisation.enabled %>
 			<%= image_tag 'ajax-loader.gif', alt: 'Loading...', title: 'Loading...', class: 'center-block' %>
 		<% end %>

--- a/app/views/authorisations/_requested_authorisation.html.erb
+++ b/app/views/authorisations/_requested_authorisation.html.erb
@@ -25,7 +25,7 @@
   </div>
   <div class="col-sm-4 col-xs-12">
 		<% requested_authorisation.possible_statuses.each do |possible_status| %>
-			<%= simple_form_for requested_authorisation, :url => authorisation_path(requested_authorisation)  do |f| %>
+			<%= simple_form_for requested_authorisation, :url => authorisation_path(requested_authorisation.token)  do |f| %>
 				<%= f.input :status, as: :hidden, :input_html => { value: possible_status } %>
 				<% if possible_status == 'granted' %>
 					<%= f.button :submit, "Grant", :class => 'btn btn-primary btn-granting pull-right' %>
@@ -38,7 +38,7 @@
 		<% end %>
 
 		<% if !['denied', 'revoked'].include? requested_authorisation.status %>
-			<a href="<%= authorisation_path(requested_authorisation) %>" class="btn btn-default btn-granting pull-right <%= 'refresh-authorisation-status' if !requested_authorisation.synced %>" <%= 'disabled=disabled' if !requested_authorisation.synced %>>
+			<a href="<%= authorisation_path(requested_authorisation.token) %>" class="btn btn-default btn-granting pull-right <%= 'refresh-authorisation-status' if !requested_authorisation.synced %>" <%= 'disabled=disabled' if !requested_authorisation.synced %>>
 				<span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span> Preview
 				<% if !requested_authorisation.synced %>
 					<%= image_tag 'ajax-loader.gif', alt: 'Loading...', title: 'Loading...' %>

--- a/app/views/authorisations/show.html.erb
+++ b/app/views/authorisations/show.html.erb
@@ -20,7 +20,7 @@
         <%= link_to 'Ask for new access', authorisation_request_path, class: 'btn btn-white pull-right' %>
       <% else %>
         <% @authorisation.possible_statuses.each do |possible_status| %>
-          <%= simple_form_for @authorisation, :url => authorisation_path(@authorisation)  do |f| %>
+          <%= simple_form_for @authorisation, :url => authorisation_path(@authorisation.token)  do |f| %>
             <%= f.input :status, as: :hidden, :input_html => { value: possible_status } %>
             <% if possible_status == 'granted' %>
               <%= f.button :submit, "Grant", :class => 'btn btn-primary btn-granting pull-right' %>
@@ -41,7 +41,7 @@
       <ul class="nav nav-pills nav-pills">
         <% [{target: 'highlight', display: 'Highlight'}, {target: 'internal', display: 'Internal'},{target: 'all', display: 'All'}].each do |tab| %>
           <li role="presentation" <%= 'class=active' if @tab_filter == tab[:target] %>>
-            <a href="<%= authorisation_path(@authorisation, tab_filter: tab[:target]) %>"><%= tab[:display] %></a>
+            <a href="<%= authorisation_path(@authorisation.token, tab_filter: tab[:target]) %>"><%= tab[:display] %></a>
           </li>
         <% end %>
       </ul>
@@ -51,7 +51,7 @@
   <div class="row container-scroll">
     <div class="col-sm-2 hidden-xs">
       <% if @viewer_type == 'requester' %>
-        <form class="form-horizontal pull-right" method="get" action="<%= authorisation_path(@authorisation) %>">
+        <form class="form-horizontal pull-right" method="get" action="<%= authorisation_path(@authorisation.token) %>">
           <div class="input-group">
             <input type="text" name="search" class="form-control" placeholder="Search for..." value="<%= @search.scope if @search %>">
             <span class="input-group-btn">
@@ -64,12 +64,12 @@
       <ul class="nav nav-pills nav-stacked">
         <% [{target: 'highlight', display: 'Highlight'}, {target: 'internal', display: 'Internal'},{target: 'all', display: 'All'}].each do |tab| %>
           <li role="presentation" <%= 'class=active' if @tab_filter == tab[:target] %>>
-            <a href="<%= authorisation_path(@authorisation, tab_filter: tab[:target]) %>"><%= tab[:display] %></a>
+            <a href="<%= authorisation_path(@authorisation.token, tab_filter: tab[:target]) %>"><%= tab[:display] %></a>
           </li>
         <% end %>
         <% @searches.each do |search| %>
           <li role="presentation" <%= 'class=active' if @search and @search.scope == search.scope %>>
-            <a href="<%= authorisation_path(@authorisation, search: search.scope) %>">
+            <a href="<%= authorisation_path(@authorisation.token, search: search.scope) %>">
               <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
               <%= search.scope %>
             </a>

--- a/db/migrate/20151207221131_add_token_to_authorisations.rb
+++ b/db/migrate/20151207221131_add_token_to_authorisations.rb
@@ -1,0 +1,6 @@
+class AddTokenToAuthorisations < ActiveRecord::Migration
+  def change
+  	add_column :authorisations, :token, :string
+  	add_index :authorisations, :token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151111001510) do
+ActiveRecord::Schema.define(version: 20151207221131) do
 
   create_table "authorisation_searches", force: true do |t|
     t.integer  "authorisation_id"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 20151111001510) do
     t.boolean  "synced"
     t.string   "status"
     t.text     "description"
+    t.string   "token"
   end
 
   add_index "authorisations", ["granter_id"], name: "index_authorisations_on_granter_id"
@@ -39,6 +40,23 @@ ActiveRecord::Schema.define(version: 20151111001510) do
   add_index "authorisations", ["requester_id"], name: "index_authorisations_on_requester_id"
   add_index "authorisations", ["status"], name: "index_authorisations_on_status"
   add_index "authorisations", ["synced"], name: "index_authorisations_on_synced"
+  add_index "authorisations", ["token"], name: "index_authorisations_on_token"
+
+  create_table "email_messages", force: true do |t|
+    t.integer  "email_thread_id"
+    t.string   "messageId"
+    t.text     "snippet"
+    t.integer  "historyId"
+    t.integer  "internalDate"
+    t.text     "body_text"
+    t.text     "body_html"
+    t.integer  "sizeEstimate"
+    t.string   "mimeType"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "email_messages", ["email_thread_id"], name: "index_email_messages_on_email_thread_id"
 
   create_table "email_threads", force: true do |t|
     t.integer  "authorisation_id"

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -2,13 +2,13 @@ namespace :testing do
 
   desc "Empty the whole database apart from Users"
   task empty_db: :environment do
-  	Authorisation.destroy_all
-  	EmailThread.destroy_all
-  	MessageAttachment.destroy_all
-  	MessageParticipant.destroy_all
-  	Participant.destroy_all
-    Tag.destroy_all
-    Label.destroy_all
+  	Authorisation.delete_all
+  	EmailThread.delete_all
+  	MessageAttachment.delete_all
+  	MessageParticipant.delete_all
+  	Participant.delete_all
+    Tag.delete_all
+    Label.delete_all
   end
 
   desc "Update tags for all threads"
@@ -30,4 +30,16 @@ namespace :testing do
       auth.sync_gmail
     end
   end
+
+  desc "Fill token for all existing authorisations following their tokenisation DB migration"
+  task tokenise_authorisations: :environment do
+    Authorisation.where(token: nil).all.each do |auth|
+      token = loop do
+        random_token = SecureRandom.urlsafe_base64(nil, false)
+        break random_token unless Authorisation.exists?(token: random_token)
+      end
+      auth.update!(token: token)
+    end
+  end
+
 end


### PR DESCRIPTION
@adeclosset this will now hide how many authorisations there are in the URL. To get it to work:
`bundle exec rake db:migrate`
`rake testing:tokenise_authorisations`
