### PR TITLE
Fix duplicated threads bug

### DIFF
--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -105,6 +105,7 @@ function download_inline_attachments() {
 	// Call the inline attachment download
 	unique_list.forEach(function(a) {
 		var download_url = $('img[src^="cid:' + a + '"]').attr('data-target');
+		console.log(download_url);
 		if(download_url != '') {
 			$.getScript(download_url);
 		}

--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -105,6 +105,8 @@ function download_inline_attachments() {
 	// Call the inline attachment download
 	unique_list.forEach(function(a) {
 		var download_url = $('img[src^="cid:' + a + '"]').attr('data-target');
-		$.getScript(download_url);
+		if(download_url != '') {
+			$.getScript(download_url);
+		}
 	});
 }

--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -9,7 +9,6 @@ $(function () {
 			more_url = $('.pagination .next_page a').attr('href');
 			if(more_url && $(window).scrollTop() > $(document).height() - $(window).height() - 180) {
 				$('.pagination').html('<img src="/assets/ajax-loader.gif" alt="Loading..." title="Loading..." />');
-            	console.log('infinite scrolling started - ' + more_url);
             	$.getScript(more_url);
 			}
 		});
@@ -105,8 +104,7 @@ function download_inline_attachments() {
 	// Call the inline attachment download
 	unique_list.forEach(function(a) {
 		var download_url = $('img[src^="cid:' + a + '"]').attr('data-target');
-		console.log(download_url);
-		if(download_url != '') {
+		if(download_url) {
 			$.getScript(download_url);
 		}
 	});

--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -9,6 +9,7 @@ $(function () {
 			more_url = $('.pagination .next_page a').attr('href');
 			if(more_url && $(window).scrollTop() > $(document).height() - $(window).height() - 180) {
 				$('.pagination').html('<img src="/assets/ajax-loader.gif" alt="Loading..." title="Loading..." />');
+            	console.log('infinite scrolling started - ' + more_url);
             	$.getScript(more_url);
 			}
 		});

--- a/app/views/authorisations/show.js.erb
+++ b/app/views/authorisations/show.js.erb
@@ -1,4 +1,3 @@
-console.log('<%= @threads.to_json %>');
 $('#results').append("<%= j render partial: 'authorisations/thread', collection: @threads %>");
 <% if @threads.next_page %>
   $('.pagination').replaceWith('<%= j will_paginate @threads %>');

--- a/app/views/authorisations/show.js.erb
+++ b/app/views/authorisations/show.js.erb
@@ -1,3 +1,4 @@
+console.log('<%= @threads.to_json %>');
 $('#results').append("<%= j render partial: 'authorisations/thread', collection: @threads %>");
 <% if @threads.next_page %>
   $('.pagination').replaceWith('<%= j will_paginate @threads %>');


### PR DESCRIPTION
@adeclosset it was a stupid bug - when an inline image can't be downloaded, it would trigger the threads to appear again for some exotic reason.
